### PR TITLE
Filtering out kernel routes

### DIFF
--- a/src/wg-autoroute.py
+++ b/src/wg-autoroute.py
@@ -65,7 +65,7 @@ def get_kernel_routes(interface, ipv6):
         logging.error("%s: Couldn't get kernel routes: %s", interface,
                       raw_routes.stderr.strip())
         return
-    routes = [route.split()[0] for route in raw_routes.stdout.split("\n") if route != ""]
+    routes = [route.split()[0] for route in raw_routes.stdout.split("\n") if route != "" and "kernel" not in route]
     # Handle "default" route
     default_route = "::/0" if ipv6 else "0.0.0.0/0"
     routes = map(lambda route: default_route if route == "default" else route,

--- a/src/wg-autoroute.py
+++ b/src/wg-autoroute.py
@@ -65,7 +65,8 @@ def get_kernel_routes(interface, ipv6):
         logging.error("%s: Couldn't get kernel routes: %s", interface,
                       raw_routes.stderr.strip())
         return
-    routes = [route.split()[0] for route in raw_routes.stdout.split("\n") if route != "" and "kernel" not in route]
+    # Exclude kernel routes from the list, generated for interface assigned ips and subnets
+    routes = [route.split()[0] for route in raw_routes.stdout.split("\n") if route != "" and "proto kernel" not in route]
     # Handle "default" route
     default_route = "::/0" if ipv6 else "0.0.0.0/0"
     routes = map(lambda route: default_route if route == "default" else route,


### PR DESCRIPTION
Kernel routes are note returned anymore by get_kernel_routes thus they are not removed as orphan routes