### PR TITLE
Set route protocol to "static"

### DIFF
--- a/src/wg-autoroute.py
+++ b/src/wg-autoroute.py
@@ -65,7 +65,7 @@ def get_kernel_routes(interface, ipv6):
         logging.error("%s: Couldn't get kernel routes: %s", interface,
                       raw_routes.stderr.strip())
         return
-    routes = [route.split()[0] for route in raw_routes.stdout.split("\n") if route != ""]
+    routes = [route.split()[0] for route in raw_routes.stdout.split("\n") if route != "" and "kernel" not in route]
     # Handle "default" route
     default_route = "::/0" if ipv6 else "0.0.0.0/0"
     routes = map(lambda route: default_route if route == "default" else route,

--- a/src/wg-autoroute.py
+++ b/src/wg-autoroute.py
@@ -65,7 +65,8 @@ def get_kernel_routes(interface, ipv6):
         logging.error("%s: Couldn't get kernel routes: %s", interface,
                       raw_routes.stderr.strip())
         return
-    routes = [route.split()[0] for route in raw_routes.stdout.split("\n") if route != "" and "kernel" not in route]
+    # Exclude kernel routes from the list, generated for interface assigned ips and subnets
+    routes = [route.split()[0] for route in raw_routes.stdout.split("\n") if route != "" and "proto kernel" not in route]
     # Handle "default" route
     default_route = "::/0" if ipv6 else "0.0.0.0/0"
     routes = map(lambda route: default_route if route == "default" else route,

--- a/src/wg-autoroute.py
+++ b/src/wg-autoroute.py
@@ -89,7 +89,7 @@ def update_peer_routes(interface, timeout, wg_peers, ipv4_routes, ipv6_routes):
                 if not (prefix in ipv4_routes or prefix in ipv6_routes):
                     logging.info("%s: [%s] Adding new prefix %s", interface,
                                  peer.public_key, prefix)
-                    ret = subprocess.run(["ip", "route", "replace", prefix, "dev", interface],
+                    ret = subprocess.run(["ip", "route", "replace", prefix, "dev", interface, "proto", "static"],
                                          encoding="ascii",
                                          capture_output=True)
                     if ret.returncode != 0:


### PR DESCRIPTION
A routing protocol like babeld ignores by default "proto boot" routes. Setting the route to "proto static" allows babeld to redistribute routes without adding a duplicate setting for proto 3